### PR TITLE
[DEV] BE 회원 정보 API 구현

### DIFF
--- a/greendev/src/main/java/com/devoceanyoung/greendev/domain/auth/api/AuthController.java
+++ b/greendev/src/main/java/com/devoceanyoung/greendev/domain/auth/api/AuthController.java
@@ -19,7 +19,8 @@ import org.springframework.web.bind.annotation.RestController;
 import com.devoceanyoung.greendev.domain.auth.dto.AccessTokenDto;
 
 import com.devoceanyoung.greendev.domain.auth.service.AuthService;
-
+import com.devoceanyoung.greendev.global.constant.StatusEnum;
+import com.devoceanyoung.greendev.global.dto.StatusResponse;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,24 +34,32 @@ public class AuthController {
 	private final AuthService authService;
 
 	@PostMapping("/blacklist")
-	public ResponseEntity<AccessTokenDto> signOut(@RequestBody AccessTokenDto requestDto) {
+	public ResponseEntity<StatusResponse> signOut(@RequestBody AccessTokenDto requestDto) {
 		AccessTokenDto resDto = authService.signOut(requestDto);
 		ResponseCookie responseCookie = removeRefreshTokenCookie();
 
 		return ResponseEntity.ok()
 			.header(SET_COOKIE, responseCookie.toString())
-			.body(resDto);
+			.body(StatusResponse.builder()
+					.status(StatusEnum.OK.getStatusCode())
+					.message(StatusEnum.OK.getCode())
+					.data(resDto)
+					.build());
+
 	}
 
 	@PostMapping("/refresh")
-	public ResponseEntity<AccessTokenDto> refresh(@CookieValue(value = "refreshToken", required = false) Cookie rtCookie) {
+	public ResponseEntity<StatusResponse> refresh(@CookieValue(value = "refreshToken", required = false) Cookie rtCookie) {
 
 		String refreshToken = rtCookie.getValue();
 
 		AccessTokenDto resDto = authService.refresh(refreshToken);
 
-		return ResponseEntity.ok()
-			.body(resDto);
+		return ResponseEntity.ok(StatusResponse.builder()
+			.status(StatusEnum.OK.getStatusCode())
+			.message(StatusEnum.OK.getCode())
+			.data(resDto)
+			.build());
 	}
 
 

--- a/greendev/src/main/java/com/devoceanyoung/greendev/domain/member/controller/MemberController.java
+++ b/greendev/src/main/java/com/devoceanyoung/greendev/domain/member/controller/MemberController.java
@@ -21,8 +21,7 @@ import com.devoceanyoung.greendev.domain.member.dto.MemberReqDto;
 import com.devoceanyoung.greendev.domain.member.dto.MemberResDto;
 import com.devoceanyoung.greendev.domain.member.service.MemberService;
 import com.devoceanyoung.greendev.global.constant.StatusEnum;
-import com.devoceanyoung.greendev.global.dto.Message;
-
+import com.devoceanyoung.greendev.global.dto.StatusResponse;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -37,9 +36,9 @@ public class MemberController {
 	@GetMapping("/me")
 	@PreAuthorize("isAuthenticated()")
 	@ResponseStatus(value = HttpStatus.OK)
-	public ResponseEntity<Message> readMember(@AuthUser Member member) {
+	public ResponseEntity<StatusResponse> readMember(@AuthUser Member member) {
 		MemberResDto response = MemberResDto.of(member);
-		return ResponseEntity.ok(Message.builder()
+		return ResponseEntity.ok(StatusResponse.builder()
 			.status(StatusEnum.OK.getStatusCode())
 			.message(StatusEnum.OK.getCode())
 			.data(response)
@@ -50,10 +49,10 @@ public class MemberController {
 	@PatchMapping("/me")
 	@PreAuthorize("isAuthenticated()")
 	@ResponseStatus(HttpStatus.OK)
-	public ResponseEntity<Message> updateNickname(@AuthUser Member member,
+	public ResponseEntity<StatusResponse> updateNickname(@AuthUser Member member,
 		@RequestBody @Valid final MemberReqDto reqDto) {
 		memberService.update(member.getMemberId(), reqDto);
-		return ResponseEntity.ok(Message.builder()
+		return ResponseEntity.ok(StatusResponse.builder()
 			.status(StatusEnum.OK.getStatusCode())
 			.message(NICKNAME_CHANGE_SUCCESS)
 			.build());

--- a/greendev/src/main/java/com/devoceanyoung/greendev/domain/member/controller/MemberController.java
+++ b/greendev/src/main/java/com/devoceanyoung/greendev/domain/member/controller/MemberController.java
@@ -1,0 +1,61 @@
+package com.devoceanyoung.greendev.domain.member.controller;
+
+import static com.devoceanyoung.greendev.global.constant.ResponseConstant.*;
+
+import javax.validation.Valid;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.devoceanyoung.greendev.domain.auth.AuthUser;
+import com.devoceanyoung.greendev.domain.member.domain.Member;
+import com.devoceanyoung.greendev.domain.member.dto.MemberReqDto;
+import com.devoceanyoung.greendev.domain.member.dto.MemberResDto;
+import com.devoceanyoung.greendev.domain.member.service.MemberService;
+import com.devoceanyoung.greendev.global.constant.StatusEnum;
+import com.devoceanyoung.greendev.global.dto.Message;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/members")
+@RequiredArgsConstructor
+public class MemberController {
+	private final MemberService memberService;
+
+	@GetMapping("/me")
+	@PreAuthorize("isAuthenticated()")
+	@ResponseStatus(value = HttpStatus.OK)
+	public ResponseEntity<Message> readMember(@AuthUser Member member) {
+		MemberResDto response = MemberResDto.of(member);
+		return ResponseEntity.ok(Message.builder()
+			.status(StatusEnum.OK.getStatusCode())
+			.message(StatusEnum.OK.getCode())
+			.data(response)
+			.build());
+	}
+
+
+	@PatchMapping("/me")
+	@PreAuthorize("isAuthenticated()")
+	@ResponseStatus(HttpStatus.OK)
+	public ResponseEntity<Message> updateNickname(@AuthUser Member member,
+		@RequestBody @Valid final MemberReqDto reqDto) {
+		memberService.update(member.getMemberId(), reqDto);
+		return ResponseEntity.ok(Message.builder()
+			.status(StatusEnum.OK.getStatusCode())
+			.message(NICKNAME_CHANGE_SUCCESS)
+			.build());
+	}
+}

--- a/greendev/src/main/java/com/devoceanyoung/greendev/domain/member/domain/Member.java
+++ b/greendev/src/main/java/com/devoceanyoung/greendev/domain/member/domain/Member.java
@@ -7,7 +7,6 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.validation.constraints.NotNull;
 
 import com.devoceanyoung.greendev.global.entity.BaseTimeEntity;
 
@@ -34,7 +33,7 @@ public class Member extends BaseTimeEntity {
 	private String profileImageUrl;
 
 	@Column(length = 50)
-	private String nickname;// 닉네임 변경 불가
+	private String nickname;
 
 	private String password;
 
@@ -61,5 +60,9 @@ public class Member extends BaseTimeEntity {
 
 	public void updateMember(String email){
 		this.email = email;
+	}
+
+	public void updateNickname(String nickname){
+		this.nickname = nickname;
 	}
 }

--- a/greendev/src/main/java/com/devoceanyoung/greendev/domain/member/dto/MemberReqDto.java
+++ b/greendev/src/main/java/com/devoceanyoung/greendev/domain/member/dto/MemberReqDto.java
@@ -1,0 +1,19 @@
+package com.devoceanyoung.greendev.domain.member.dto;
+
+import javax.validation.constraints.NotBlank;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberReqDto {
+
+	@NotBlank(message = "닉네임은 필수입니다. ")
+	private String nickname;
+
+	public MemberReqDto(String nickname) {
+		this.nickname = nickname;
+	}
+}

--- a/greendev/src/main/java/com/devoceanyoung/greendev/domain/member/dto/MemberResDto.java
+++ b/greendev/src/main/java/com/devoceanyoung/greendev/domain/member/dto/MemberResDto.java
@@ -1,0 +1,27 @@
+package com.devoceanyoung.greendev.domain.member.dto;
+
+import com.devoceanyoung.greendev.domain.member.domain.Member;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberResDto {
+	private String email;
+	private String nickname;
+	private String profileImageUrl;
+
+	public static MemberResDto of(Member member){
+		return MemberResDto.builder()
+			.email(member.getEmail())
+			.nickname(member.getNickname())
+			.profileImageUrl(member.getProfileImageUrl())
+			.build();
+	}
+
+
+}

--- a/greendev/src/main/java/com/devoceanyoung/greendev/domain/member/service/MemberService.java
+++ b/greendev/src/main/java/com/devoceanyoung/greendev/domain/member/service/MemberService.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.devoceanyoung.greendev.domain.member.domain.Member;
+import com.devoceanyoung.greendev.domain.member.dto.MemberReqDto;
 import com.devoceanyoung.greendev.domain.member.repository.MemberRepository;
 import com.devoceanyoung.greendev.global.exception.customException.MemberNotFoundException;
 
@@ -16,6 +17,12 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class MemberService {
 	final private MemberRepository memberRepository;
+
+	public void update(Long memberId, MemberReqDto reqDto) {
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(MemberNotFoundException::new);
+		member.updateNickname(reqDto.getNickname());
+	}
 	@Transactional(readOnly = true)
 	public boolean isExistedEmail(String email){
 		return memberRepository.existsByEmail(email);

--- a/greendev/src/main/java/com/devoceanyoung/greendev/global/constant/ResponseConstant.java
+++ b/greendev/src/main/java/com/devoceanyoung/greendev/global/constant/ResponseConstant.java
@@ -2,4 +2,6 @@ package com.devoceanyoung.greendev.global.constant;
 
 public class ResponseConstant {
 	public static final String MEMBER_NOT_FOUND = "해당 계정을 찾을 수 없습니다.";
+	public static final String NICKNAME_CHANGE_SUCCESS = "성공적으로 닉네임이 변경되었습니다.";
+
 }

--- a/greendev/src/main/java/com/devoceanyoung/greendev/global/constant/StatusEnum.java
+++ b/greendev/src/main/java/com/devoceanyoung/greendev/global/constant/StatusEnum.java
@@ -1,0 +1,21 @@
+package com.devoceanyoung.greendev.global.constant;
+
+import lombok.Getter;
+
+@Getter
+public enum StatusEnum {
+
+	OK(200, "SUCCESS"),
+	CREATED(201, "CREATED"),
+	BAD_REQUEST(400, "BAD_REQUEST"),
+	NOT_FOUND(404, "NOT_FOUND"),
+	INTERNAL_SERER_ERROR(500, "INTERNAL_SERVER_ERROR");
+
+	Integer statusCode;
+	String code;
+
+	StatusEnum(Integer statusCode, String code) {
+		this.statusCode = statusCode;
+		this.code = code;
+	}
+}

--- a/greendev/src/main/java/com/devoceanyoung/greendev/global/dto/StatusResponse.java
+++ b/greendev/src/main/java/com/devoceanyoung/greendev/global/dto/StatusResponse.java
@@ -1,0 +1,19 @@
+package com.devoceanyoung.greendev.global.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.Builder;
+import lombok.Getter;
+
+
+@Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class StatusResponse {
+
+	private Integer status;
+	private String message;
+	private Object data;
+
+
+}


### PR DESCRIPTION
## Summary 
회원의 정보를 조회하는 API를 구현합니다. 
  
## Description 
 - 회원 정보 (이메일, 프로필 사진, 닉네임) 조회 API 구현합니다.
 - 닉네임 수정 API 를 구현합니다.
 
### GET  {도메인이름}/api/v1/members/me
 - 회원 정보 (이메일, 프로필 사진, 닉네임) 조회 API  응답값
```json
{
    "status": 200,
    "message": "SUCCESS",
    "data": {
        "email": "ziyun1612@naver.com",
        "nickname": "dev",
        "profileImageUrl": "https://phinf.pstatic.net/contact/20200623_268/1592901094691BqKER_JPEG/image.jpg"
    }
}
```

### PATCH  {도메인이름}/api/v1/members/me
 - 닉네임 수정 API 응답값
```json
{
    "status": 200,
    "message": "성공적으로 닉네임이 변경되었습니다."
}
```

