### PR TITLE
[FIX] 서브 도메인 인식 해결

### DIFF
--- a/greendev/src/main/java/com/devoceanyoung/greendev/domain/auth/service/OAuth2AuthenticationSuccessHandler.java
+++ b/greendev/src/main/java/com/devoceanyoung/greendev/domain/auth/service/OAuth2AuthenticationSuccessHandler.java
@@ -138,7 +138,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
 		return ResponseCookie.from("refreshToken", refreshToken)
 			.path("/") // 해당 경로 하위의 페이지에서만 쿠키 접근 허용. 모든 경로에서 접근 허용한다.
-			.domain("dev-lr.com")
+			.domain(".dev-lr.com")
 			.maxAge(TimeUnit.MILLISECONDS.toSeconds(refreshTokenValidationMs)) // 쿠키 만료 시기(초). 없으면 브라우저 닫힐 때 제거
 			.secure(true) // HTTPS로 통신할 때만 쿠키가 전송된다.
 			.sameSite("None")


### PR DESCRIPTION
## Summary
서브 도메인을 인식하기 위해서 "."이 필요하므로 추가


## Description
- 서브 도메인을 인식하기 위해서  .domain("{주소}") -> .domain(".{주소}") 로 변경
