### PR TITLE
[FIX] 앱에서 딥링크로 리다이렉션할 때 오류 해결

### DIFF
--- a/greendev/src/main/java/com/devoceanyoung/greendev/domain/auth/api/AuthAppController.java
+++ b/greendev/src/main/java/com/devoceanyoung/greendev/domain/auth/api/AuthAppController.java
@@ -1,0 +1,58 @@
+package com.devoceanyoung.greendev.domain.auth.api;
+
+import com.devoceanyoung.greendev.domain.auth.dto.AccessTokenDto;
+import com.devoceanyoung.greendev.domain.auth.dto.RefreshAccessTokenReqDto;
+import com.devoceanyoung.greendev.domain.auth.dto.RefreshTokenResDto;
+import com.devoceanyoung.greendev.domain.auth.service.AuthService;
+import com.devoceanyoung.greendev.global.constant.StatusEnum;
+import com.devoceanyoung.greendev.global.dto.StatusResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.http.ResponseEntity;
+
+import org.springframework.web.bind.annotation.*;
+
+
+@Slf4j
+@RestController
+@RequestMapping("api/v1/app/token")
+@RequiredArgsConstructor
+public class AuthAppController {
+    private final AuthService authService;
+
+    @PostMapping("/refreshToken")
+    public ResponseEntity<StatusResponse> getRefreshToken(@RequestBody AccessTokenDto accessTokenDto){
+        RefreshTokenResDto resDto = authService.getRefreshToken(accessTokenDto);
+        return ResponseEntity.ok(StatusResponse.builder()
+                .status(StatusEnum.OK.getStatusCode())
+                .message(StatusEnum.OK.getCode())
+                .data(resDto)
+                .build());
+
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<StatusResponse> refresh(@RequestBody RefreshAccessTokenReqDto reqDto) {
+        AccessTokenDto resDto = authService.refresh(reqDto.getRefreshToken());
+
+        return ResponseEntity.ok(StatusResponse.builder()
+                .status(StatusEnum.OK.getStatusCode())
+                .message(StatusEnum.OK.getCode())
+                .data(resDto)
+                .build());
+    }
+
+    @PostMapping("/blacklist")
+    public ResponseEntity<StatusResponse> signOut(@RequestBody AccessTokenDto requestDto) {
+        AccessTokenDto resDto = authService.signOut(requestDto);
+
+        return ResponseEntity.ok()
+                .body(StatusResponse.builder()
+                        .status(StatusEnum.OK.getStatusCode())
+                        .message(StatusEnum.OK.getCode())
+                        .data(resDto)
+                        .build());
+
+    }
+}

--- a/greendev/src/main/java/com/devoceanyoung/greendev/domain/auth/dto/RefreshAccessTokenReqDto.java
+++ b/greendev/src/main/java/com/devoceanyoung/greendev/domain/auth/dto/RefreshAccessTokenReqDto.java
@@ -1,0 +1,19 @@
+package com.devoceanyoung.greendev.domain.auth.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshAccessTokenReqDto {
+
+    @NotBlank(message = "RefreshToken은 필수로 입력되어야 합니다.")
+    private String refreshToken;
+
+    public RefreshAccessTokenReqDto(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+}

--- a/greendev/src/main/java/com/devoceanyoung/greendev/domain/auth/dto/RefreshTokenResDto.java
+++ b/greendev/src/main/java/com/devoceanyoung/greendev/domain/auth/dto/RefreshTokenResDto.java
@@ -1,0 +1,17 @@
+package com.devoceanyoung.greendev.domain.auth.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshTokenResDto {
+    private String refreshToken;
+    private Long refreshTokenRemaininTime;
+
+    public RefreshTokenResDto(String refreshToken, Long refreshTokenRemaininTime) {
+        this.refreshToken = refreshToken;
+        this.refreshTokenRemaininTime = refreshTokenRemaininTime;
+    }
+}

--- a/greendev/src/main/java/com/devoceanyoung/greendev/domain/auth/service/AuthService.java
+++ b/greendev/src/main/java/com/devoceanyoung/greendev/domain/auth/service/AuthService.java
@@ -1,14 +1,15 @@
 package com.devoceanyoung.greendev.domain.auth.service;
 
+import com.devoceanyoung.greendev.domain.auth.dto.RefreshTokenResDto;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+
 import org.springframework.security.core.Authentication;
-import org.springframework.security.crypto.password.PasswordEncoder;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.devoceanyoung.greendev.domain.auth.dto.AccessTokenDto;
-import com.devoceanyoung.greendev.domain.member.repository.MemberRepository;
+
 import com.devoceanyoung.greendev.global.jwt.JwtProvider;
 import com.devoceanyoung.greendev.global.redis.RedisService;
 
@@ -72,4 +73,13 @@ public class AuthService {
 	}
 
 
+	public RefreshTokenResDto getRefreshToken(AccessTokenDto accessTokenDto) {
+		Authentication authentication = jwtProvider.getAuthentication(accessTokenDto.getAccessToken());
+
+		// Redis의 RefreshToken을 가져오면서, 이미 로그아웃된 사용자인 경우 예외 처리
+		String refreshToken = redisService.getRefreshToken(authentication.getName())
+				.orElseThrow(() -> new RuntimeException("RefreshToken NotFound:" + authentication.getName()));
+		Long remainingTime = jwtProvider.getRemainingTime(refreshToken);
+		return new RefreshTokenResDto(refreshToken, remainingTime);
+	}
 }

--- a/greendev/src/main/java/com/devoceanyoung/greendev/domain/member/service/UserDetailsServcieImpl.java
+++ b/greendev/src/main/java/com/devoceanyoung/greendev/domain/member/service/UserDetailsServcieImpl.java
@@ -1,5 +1,6 @@
 package com.devoceanyoung.greendev.domain.member.service;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -14,13 +15,14 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class UserDetailsServcieImpl implements UserDetailsService {
 	private final MemberRepository
 		memberRepository;
 
 	@Override
 	public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-		System.out.println(email);
+		log.info(email);
 		Member member = memberRepository.findByEmail(email).orElseThrow(
 			MemberNotFoundException::new);
 


### PR DESCRIPTION
## Summary
앱에서 딥링크로 리다이렉션할 때 오류를 해결

## Description
- redirect_uri를 받아 엑세스 토큰을 반환할 때 웹 브라우저와 딥링크일 경우를 분기하여 다르게 uri를 build합니다. 
- 딥링크는 쿠키 정보를 받을 수 없으므로 웹 브라우저일 때 쿠키로 refreshToken을 주고 받는 로직을 api의 body로 주고 받을 수 있도록 api를 추가했습니다. 
    1) refreshToken 조회 = 웹브라우저에서는 로그인 시 쿠키로 refreshToken값과 만료시간을 전달 -> app에서는 refreshToken 조회 api를 두어 호출하여 확인하면 됩니다. 
    2) 엑세스 토큰 재발급 = 웹 브라우저에서는 쿠키로 보낸 refreshToken 정보를 받아 유효한지 판단후 엑세스 토큰을 재발급 -> app에서는 requestBody로 refreshToken을 보내시면 됩니다!
    3) 로그아웃 = 웹브라우저에서는 accessToken을 담아 보내면 blacklist에 올리고 refreshToken 쿠키값을 지웁니다 -> app은 똑같이 accessToken을 담아 보내면 blacklist에 올립니다. 다만, 앱에 저장하고 있는 refreshToken 값을 알아서 버리시면 됩니다! 


## Description

## 로그인 후 refreshToken 조회 
[POST] /api/v1/app/token/refreshToken
로그인 후 얻은 accessToken을 가지고 refreshToken을 조회합니다.
이때, 유효한 시간(남은 시간)은 refreshTokenRemaininTime 으로 보냅니다. (Long, 밀리초(milliseconds) 단위)

```json
{
    "status": 200,
    "message": "SUCCESS",
    "data": {
        "refreshToken": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ6aXl1bjE2MTJAZXdoYWluLm5ldCIsImlhdCI6MTY5NzU1NDk2MiwiZXhwIjoxNjk4ODUwOTYyfQ.RjQgb8fem8IKd119c1RGYID1pv4ankkZ6zcWxKR-V5M",
        "refreshTokenRemaininTime": 1295952565
    }
}
```

## accessToken 재발급
[POST] /api/v1/app/token/refresh
```json
{
    "status": 200,
    "message": "SUCCESS",
    "data": {
        "accessToken": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ6aXl1bjE2MTJAZXdoYWluLm5ldCIsImlhdCI6MTY5NzU1NTEyNiwiZXhwIjoxNjk3NTU2OTI2fQ.JH1Y-voMwPz8Dkpk5aW0ewfsgkhVHImP4IlwBTxA9PU"
    }
}
```

## 로그아웃
[POST] /api/v1/app/token/blacklist

```json
{
    "status": 200,
    "message": "SUCCESS",
    "data": {
        "accessToken": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ6aXl1bjE2MTJAZXdoYWluLm5ldCIsImlhdCI6MTY5NzU1NTEyNiwiZXhwIjoxNjk3NTU2OTI2fQ.JH1Y-voMwPz8Dkpk5aW0ewfsgkhVHImP4IlwBTxA9PU"
    }
}
```