### PR TITLE
[FIX] 카카오, 네이버 로그인 시 사용자 정보 null일 경우 처리

### DIFF
--- a/greendev/src/main/java/com/devoceanyoung/greendev/domain/auth/domain/NaverUserInfo.java
+++ b/greendev/src/main/java/com/devoceanyoung/greendev/domain/auth/domain/NaverUserInfo.java
@@ -54,7 +54,11 @@ public class NaverUserInfo implements OAuth2UserInfo{
 
 	public String getNickname() {
 		Object nicknameObj = attributes.get(NICKNAME);
-		return nicknameObj == null ? null : nicknameObj.toString();
+		if(nicknameObj == null){
+			String email = getEmail();
+			return email.substring(0, email.indexOf("@"));
+		}
+		return nicknameObj.toString();
 	}
 	@Override
 	public String getProfileImageUrl(){

--- a/greendev/src/main/java/com/devoceanyoung/greendev/domain/auth/dto/AppLoginReqDto.java
+++ b/greendev/src/main/java/com/devoceanyoung/greendev/domain/auth/dto/AppLoginReqDto.java
@@ -14,13 +14,10 @@ public class AppLoginReqDto {
             regexp = "^[\\w!#$%&'*+/=?`{|}~^-]+(?:\\.[\\w!#$%&'*+/=?`{|}~^-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,6}$")
     private String email;
 
-    @NotBlank(message = "닉네임은 필수입니다. ")
     private String nickname;
 
-    @NotBlank(message = "사진은 필수입니다.")
     private String profileImageUrl;
 
-    @NotBlank(message = "username은 필수입니다.")
     private String username;
 
     public AppLoginReqDto(String email, String nickname, String profileImageUrl) {

--- a/greendev/src/main/java/com/devoceanyoung/greendev/global/util/ConstantUtils.java
+++ b/greendev/src/main/java/com/devoceanyoung/greendev/global/util/ConstantUtils.java
@@ -1,0 +1,5 @@
+package com.devoceanyoung.greendev.global.util;
+
+public class ConstantUtils {
+    public static final String BASE_PROFILE_IMAGE = "https://user-images.githubusercontent.com/76603301/281514325-e33574ba-58aa-4b80-a1bf-0167a3e76d5e.png";
+}


### PR DESCRIPTION
## Summary
카카오, 네이버 로그인 시 사용자 정보 null일 경우 처리

## Description
- api/v1/app/token/login/naver 와 api/v1/app/token/login/kakao 요청 시 email 을 제외한 프로필 사진, 닉네임의 경우 null이 올 수 있으므로 이때 기본값으로 처리하는 로직 구현
(로그인 응답값은 변경하지 않았습니다)